### PR TITLE
Add quotes to arguments beginning by @

### DIFF
--- a/Resources/config/security.yml
+++ b/Resources/config/security.yml
@@ -17,7 +17,7 @@ services:
 
     saml.security.authentication.listener:
         class: PDias\SamlBundle\Security\Firewall\SamlListener
-        arguments: [@security.token_storage, @security.authentication.manager, @security.access.decision_manager, @security.access_map, @security.http_utils, @event_dispatcher, @samlauth.service, @?logger, {}]
+        arguments: ['@security.token_storage', '@security.authentication.manager', '@security.access.decision_manager', '@security.access_map', '@security.http_utils', '@event_dispatcher', '@samlauth.service', '@?logger', {}]
 
     saml.service.user.provider:
         public: false
@@ -27,7 +27,7 @@ services:
     saml.security.http.logout:
         public: false
         class: PDias\SamlBundle\Security\Handlers\SamlLogoutHandler
-        arguments: [@samlauth.service, @security.http_utils, {}]
+        arguments: ['@samlauth.service', '@security.http_utils', {}]
 
     #saml.security.authentication.success_handler:
     #    class: PDias\SamlBundle\Security\EntryPoint\SamlAuthenticationEntryPoint


### PR DESCRIPTION
since symfony 2.8 YAML tags beginning by @ and ` must be quoted 
https://github.com/symfony/symfony/issues/16234