### PR TITLE
added quotes to arguments beginning by @ in twig.yml

### DIFF
--- a/Resources/config/twig.yml
+++ b/Resources/config/twig.yml
@@ -10,4 +10,4 @@ services:
         class: PDias\SamlBundle\Twig\Extension\SamlExtension
         tags: [{ name: twig.extension }]
         public: false
-        arguments: [@router]
+        arguments: ['@router']


### PR DESCRIPTION
since symfony 2.8 YAML tags beginning by @ and ` must be quoted 
https://github.com/symfony/symfony/issues/16234